### PR TITLE
One simple trick, discovered by a Doug, for calculating build numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 packages/
 coverage/
 .grapplehound.json
+fauxgitaboudit/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.2.*
+
+### 0.2.0
+
+ * Change how build numbers are calculated
+   * Simplify the process previously used to fewer steps
+   * Better leveraging of git's CLI features
+   * Count all commits since the version was changed
+ * Add a script to create a one-off git repository so that tests can run anywhere
+ * Rework the git module API
+ * Replace cp, mv and rimraf with fs-extra
+
 ## 0.1.*
 
 ### 0.1.9

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ This library provides all functionality around the creation and handling of arti
 
 It is unlikely that you would consume this library directly unless you are working on a package host, build agent, CLI or service host. There are already nonstop projects for each of these use cases.
 
+## Running the tests
+Before you can run the tests, you'll need to run the `./preTest.sh` script that creates a git repository for testing. Failure to do that will result in a lot of failed tests.
+
 ## Packages
 
 ### Information

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nonstop-pack",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Lib for working with nonstop packages",
   "main": "src/package.js",
   "scripts": {
@@ -22,6 +22,11 @@
     {
       "name": "Alex Robson",
       "url": "http://nerdventure.io"
+    },
+    {
+      "name": "Doug Neiner",
+      "email": "doug@dougneiner.com",
+      "url": "http://code.dougneiner.com"
     }
   ],
   "license": "MIT",
@@ -35,6 +40,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "chai-as-promised": "^5.1.0",
+    "drudgeon": "^0.2.0",
     "gulp": "^3.8.7",
     "gulp-istanbul": "^0.5.0",
     "gulp-mocha": "^1.0.0",
@@ -43,13 +49,10 @@
   "dependencies": {
     "archiver": "^0.11.0",
     "configya": "~0.2.0",
-    "cp": "^0.2.0",
     "debug": "^2.0.0",
+    "fs-extra": "^0.26.2",
     "globulesce": "~0.1.4",
     "lodash": "^2.4.1",
-    "mkdirp": "^0.5.0",
-    "mv": "^2.1.1",
-    "rimraf": "^2.2.8",
     "semver": "^3.0.1",
     "tar-fs": "^0.5.0",
     "when": "^3.4.5"

--- a/preTest.sh
+++ b/preTest.sh
@@ -1,0 +1,38 @@
+mkdir ./fauxgitaboudit
+cd ./fauxgitaboudit
+git init
+echo "{\"version\":\"0.1.0\"}" > ./package.json
+git add .
+git commit -m "initial commit"
+echo 1 > change.log
+git add .
+git commit -m "commit 1"
+echo 2 >> change.log
+git add .
+git commit -m "commit 2"
+echo 3 > change.log
+git add .
+git commit -m "commit 3"
+echo 4 > change.log
+git add .
+git commit -m "commit 4"
+echo 5 > change.log
+git add .
+git commit -m "commit 5"
+echo "{\"version\":\"0.1.1\"}" > ./package.json
+echo 6 > change.log
+git add .
+git commit -m "commit 6"
+echo 7 > change.log
+git add .
+git commit -m "commit 7"
+echo 8 > change.log
+git add .
+git commit -m "commit 8"
+echo "{\"version\":\"0.1.1\",\"name\":\"test\"}" > ./package.json
+echo 9 > change.log
+git add .
+git commit -m "commit 9"
+echo 10 > change.log
+git add .
+git commit -m "commit 10"

--- a/spec/git.spec.js
+++ b/spec/git.spec.js
@@ -2,68 +2,52 @@ require( './setup' );
 var path = require( 'path' );
 var git = require( '../src/git.js' );
 
-describe( 'when getting basic information', function() {
-	var repoInfo;
+describe( 'Git', function() {
+	describe( 'when getting basic information', function() {
+		var repoInfo;
 
-	before( function( done ) {
-		git.repo( './' )
-			.then( function( info ) {
-				repoInfo = info;
-				done();
-			} );
+		before( function( done ) {
+			git.repo( './fauxgitaboudit' )
+				.then( function( info ) {
+					repoInfo = info;
+					done();
+				} );
+		} );
+
+		it( 'should retrieve necessary repository data from environment', function() {
+			repoInfo.owner.should.equal( 'anonymous' );
+			repoInfo.repository.should.equal( 'norepo' );
+			repoInfo.branch.should.equal ( 'master' );
+			repoInfo.path.should.equal( path.resolve( './fauxgitaboudit' ) );
+			repoInfo.build.should.equal( 5 );
+			repoInfo.commit.length.should.equal( 40 );
+		} );
 	} );
 
-	it( 'should retrieve necessary repository data from environment', function() {
-		repoInfo.owner.should.equal( 'arobson' );
-		repoInfo.repository.should.equal( 'nonstop-pack' );
-		repoInfo.branch.should.equal ( 'master' );
-		repoInfo.path.should.equal( path.resolve( './' ) );
-		repoInfo.commit.length.should.equal( 40 );
-	} );
-} );
+	describe( 'when getting branch from drone', function() {
+		var repoInfo;
 
-describe( 'when getting branch from drone', function() {
-	var repoInfo;
+		before( function() {
+			process.env.DRONE = true;
+			process.env.DRONE_BRANCH = 'testing';
+			return git.repo( './fauxgitaboudit' )
+				.then( function( info ) {
+					repoInfo = info;
+				} );
+		} );
 
-	before( function() {
-		process.env.DRONE = true;
-		process.env.DRONE_BRANCH = 'testing';
-		return git.repo( './' )
-			.then( function( info ) {
-				repoInfo = info;
-			} );
-	} );
+		it( 'should retrieve expected repository data from environment', function() {
+			repoInfo.owner.should.equal( 'anonymous' );
+			repoInfo.repository.should.equal( 'norepo' );
+			repoInfo.branch.should.equal ( 'testing' );
+			repoInfo.path.should.equal( path.resolve( './fauxgitaboudit' ) );
+			repoInfo.build.should.equal( 5 );
+			repoInfo.commit.length.should.equal( 40 );
+		} );
 
-	it( 'should retrieve expected repository data from environment', function() {
-		repoInfo.owner.should.equal( 'arobson' );
-		repoInfo.repository.should.equal( 'nonstop-pack' );
-		repoInfo.branch.should.equal ( 'testing' );
-		repoInfo.path.should.equal( path.resolve( './' ) );
-		repoInfo.commit.length.should.equal( 40 );
-	} );
-
-	after( function() {
-		delete process.env.DRONE;
-		delete process.env.DRONE_BRANCH;
-	} );
-} );
-
-describe( 'when looking up version history', function() {
-	var versionHistory;
-
-	before( function( done ) {
-		git.getVersionsFor( './package.json', './' )
-			.then( function( list ) {
-				versionHistory = list;
-				done();
-			} );
-	} );
-
-	it( 'should have at least one version entry', function() {
-		versionHistory[ 0 ].should.eql( {
-			sha: '75b73a17ef82f451511a377ecf2149d81ce2fc17',
- 			version: '0.1.0',
- 			build: 1
- 		} );
+		after( function() {
+			delete process.env.DRONE;
+			delete process.env.DRONE_BRANCH;
+		} );
 	} );
 } );

--- a/spec/version.spec.js
+++ b/spec/version.spec.js
@@ -1,50 +1,50 @@
 require( './setup' );
 var seq = require( 'when/sequence' );
 var version = require( '../src/version.js' );
-
-describe( 'should find correct version file', function() {
-	var dotnetVersion, erlangVersion, nodeVersion;
-	var getFile = function( relativePath ) {
-		return function() {
-			return version.getFile( relativePath );
+describe( 'Version', function() {
+	describe( 'should find correct version file', function() {
+		var dotnetVersion, erlangVersion, nodeVersion;
+		var getFile = function( relativePath ) {
+			return function() {
+				return version.getFile( relativePath );
+			};
 		};
-	};
-	var getVersion = function( versionFile ) {
-		return function() {
-			return version.getVersion( versionFile );
+		var getVersion = function( versionFile ) {
+			return function() {
+				return version.getVersion( versionFile );
+			};
 		};
-	};
 
-	before( function( done ) {
-		seq( [
-				getFile( './spec/versioning/node/' ),
-				getFile( './spec/versioning/erlang/' ),
-				getFile( './spec/versioning/dotnet/' )
-			] )
-		.then( function( paths ) {
-			seq( [
-				getVersion( paths[ 0 ] ),
-				getVersion( paths[ 1 ] ),
-				getVersion( paths[ 2 ] )
-			] )
-			.then( function( versions ) {
-				dotnetVersion = versions[ 2 ];
-				erlangVersion = versions[ 1 ];
-				nodeVersion = versions[ 0 ];
-				done();
+		before( function() {
+			return seq( [
+					getFile( './spec/versioning/node/' ),
+					getFile( './spec/versioning/erlang/' ),
+					getFile( './spec/versioning/dotnet/' )
+				] )
+			.then( function( paths ) {
+				return seq( [
+					getVersion( paths[ 0 ] ),
+					getVersion( paths[ 1 ] ),
+					getVersion( paths[ 2 ] )
+				] )
+				.then( function( versions ) {
+					dotnetVersion = versions[ 2 ];
+					erlangVersion = versions[ 1 ];
+					nodeVersion = versions[ 0 ];
+				} );
 			} );
 		} );
-	} );
 
-	it( 'should retrieve the correct dotnet version', function() {
-		dotnetVersion.should.equal( '4.3.2' );
-	} );
+		it( 'should retrieve the correct dotnet version', function() {
+			dotnetVersion.should.equal( '4.3.2' );
+		} );
 
-	it( 'should retrieve the correct erlang version', function() {
-		erlangVersion.should.equal( '1.0.1' );
-	} );
+		it( 'should retrieve the correct erlang version', function() {
+			erlangVersion.should.equal( '1.0.1' );
+		} );
 
-	it( 'should retrieve the correct node version', function() {
-		nodeVersion.should.equal( '0.1.2' );
+		it( 'should retrieve the correct node version', function() {
+			nodeVersion.should.equal( '0.1.2' );
+		} );
 	} );
 } );

--- a/src/version.js
+++ b/src/version.js
@@ -1,8 +1,8 @@
 var _ = require( 'lodash' );
-var when = require( 'when' );
 var glob = require( 'globulesce' );
 var path = require( 'path' );
 var fs = require( 'fs' );
+var format = require( 'util' ).format;
 
 function parseErlangVersion( content ) {
 	var regex = /[{]\W?vsn[,]\W?\"([0-9.]+)\"/;
@@ -27,11 +27,22 @@ var parsers = {
 	'.cs': parseDotNetVersion
 };
 
-var searchPaths = [ 
+var searchPaths = [
 	'{.,**}/package.json',
 	'{.,**}/*.app.src',
 	'{.,**}/AssemblyInfo.cs'
 ];
+
+var searchTemplates = {
+	'.src': '[{]\W?vsn[,]\W?\\"%s\\"',
+	'.json': '\\"version\\"\S*[:]\S*\\"%s\\"',
+	'.cs': '^\\[assembly:\W?[aA]ssemblyVersion(Attribute)?\W?\\(\W?\\"%s\\"\W*$'
+};
+
+function getTemplate( filePath, version ) {
+	var ext = path.extname( filePath );
+	return format( searchTemplates[ ext ], version );
+}
 
 function getVersionFile( projectPath ) {
 	var resolvedPath = path.resolve( projectPath );
@@ -42,8 +53,7 @@ function getVersionFile( projectPath ) {
 			} else {
 				return x[ 0 ];
 			}
-		} )
-		.then( null, function( err ) {
+		}, function() {
 			throw new Error( 'Cannot search for version files in bad path "' + projectPath + '"' );
 		} );
 }
@@ -58,5 +68,6 @@ function getVersion( filePath, content ) {
 
 module.exports = {
 	getFile: getVersionFile,
+	getTemplate: getTemplate,
 	getVersion: getVersion
 };


### PR DESCRIPTION
 * Change how build numbers are calculated
   * Simplify the process previously used to fewer steps
   * Better leveraging of git's CLI features
   * Count all commits since the version was changed
 * Add a script to create a one-off git repository so that tests can run anywhere
 * Rework the git module API